### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+permissions:
+  contents: write # Allow to create a release.
+
+jobs:
+  build:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set env
+        run:  echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Install go
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: '=1.22'
+
+      - name: Cenerate release artifacts
+        run: |
+          make release
+
+      - name: Release
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
+        with:
+          files: out/*
+          draft: true
+          body_path: _releasenotes/release-notes-${{ env.RELEASE_TAG }}.md

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,11 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 0
+    minor: 1
+    contract: v1beta1


### PR DESCRIPTION
# Description

This PR updates `Makefile` to add release actions (and some other, including cleanup) and creates a new GitHub Actions workflow for creating a new release when a tag `v*` is pushed.

Fixes #17 